### PR TITLE
introduce crash check in log tailing

### DIFF
--- a/lib/unity-log-streamer.ts
+++ b/lib/unity-log-streamer.ts
@@ -25,10 +25,15 @@ export class UnityLogStreamer {
             fsWatchOptions: { interval: 1009 }
         });
 
-        logTail.on("line", function (data) { console.log(data); });
-        logTail.on("error", function (error) { console.log('ERROR: ', error); });
-
         let result = -1;
+
+        logTail.on("line", function (data) { 
+            console.log(data); 
+            if (data.includes('Crash!!!')) {
+                result = -1;
+            }
+        });
+        logTail.on("error", function (error) { console.log('ERROR: ', error); });
 
         try {
             result = await execResult;


### PR DESCRIPTION
Hello, and thanks for your work in the journey of headless automated build for Unity.

I have a project that crashes during import. Since it crashes on managed side, no exception can be catched. 
However, I noticed that when such a crash occurs, you can find a **Crash!!!** string inside the log file.
This PR check against the presence of this string in each log line, returning negative exit code when found.
I have barely ever programmed in node js so dunno if it is good enough to be integrated. 
